### PR TITLE
Fix: Properly parse trandata from request content before decryption

### DIFF
--- a/src/Services/KnetResponseService.php
+++ b/src/Services/KnetResponseService.php
@@ -48,14 +48,23 @@ class KnetResponseService
      */
     public static function decryptAndParse(Request $request): array
     {
-        $trandata = $request->getContent();
+        // 1. Get the full request content
+        $content = $request->getContent();
+
+        // 2. Parse the content into an array
+        parse_str($content, $output);
+
+        // 3. Extract only the trandata field
+        $trandata = $output['trandata'] ?? null;
 
         if (! $trandata) {
             throw new AccessDeniedHttpException('Invalid Request');
         }
 
+        // 4. Decrypt only the trandata field
         $payload = KPayClient::decryptAES($trandata, config('knet.resource_key'));
 
+        // 5. Parse the decrypted result
         parse_str($payload, $payloadArray);
 
         if (! isset($payloadArray['trackid'])) {


### PR DESCRIPTION
**Problem**

- The decryptAndParse() function was attempting to decrypt the entire request content instead of only the trandata field.

**Solution**

- Modified the function to properly extract the trandata before decryption

